### PR TITLE
Fix nextRef

### DIFF
--- a/@confuzzle/confuz-parser/builder.js
+++ b/@confuzzle/confuz-parser/builder.js
@@ -36,15 +36,11 @@ function parseAndBuild(input, compiling) {
         }
       }
       
-      let nextRefId = '';
       for (let i = 0; i < clue.refIds.length; i++) {
         if (clue.refIds[i] != clueid) {
           clue.refs.push(cw.clues[clue.refIds[i]]);
-        } else {
-          nextRefId = clue.refIds[i + 1];
         }
       }
-      clue.nextRef = nextRefId ? cw.clues[nextRefId] : null;
 
       // populate crossword across and down clues for convenience
       if (clue.isAcross) {
@@ -123,6 +119,23 @@ function parseAndBuild(input, compiling) {
     cw.downClues.sort((a, b) => {
         return a.row != b.row ? a.row - b.row : a.col - b.col;
     });
+
+    for (let [i, clue_i] of cw.acrossClues.entries()) {
+        if (i == cw.acrossClues.length - 1) {
+            clue_i.nextRef = cw.downClues[0];
+        } else {
+            clue_i.nextRef = cw.acrossClues[i + 1];
+        }
+    }
+    for (let [i, clue_i] of cw.downClues.entries()) {
+        if (i == cw.downClues.length - 1) {
+            // Loop back around
+            clue_i.nextRef = cw.acrossClues[0];
+        } else {
+            clue_i.nextRef = cw.downClues[i + 1];
+        }
+    }
+    
     return cw;
 }
 


### PR DESCRIPTION
This change makes it so that nextRef is the next across or down clue.  This logic is moved to after the across and down clues are sorted.

The current logic isn't clear, but appears to not work, because whenever you hit the end of a word, it does not go on to the next word, which is what this logic should do:
https://github.com/rjkat/confuzzle/blob/258a78b03a3fd4c80ba9708c799f0acdc5357381/client/components/CfzCrosswordGrid.vue#L328
This bug is reproducible with any word on the sample puzzle