### PR TITLE
Don't deselect clue after reaching end of the clue

### DIFF
--- a/client/components/CfzCrosswordGrid.vue
+++ b/client/components/CfzCrosswordGrid.vue
@@ -335,7 +335,7 @@ export default Vue.extend({
               col = cell.col;
           }
           const backspace = direction == -1;
-          
+
           // we've run off the end or hit an empty square
           if (   row < 0 || row >= cells.length
               || col < 0 || col >= cells[row].length
@@ -348,12 +348,11 @@ export default Vue.extend({
                       this.inputAcross = next.isAcross;
                       this.selectCell(next.cells[0]);
                   } else {
+                      // only move if nextRef is set
                       if (this.selectedClue && this.selectedClue.nextRef) {
                           const next = this.selectedClue.nextRef;
                           this.inputAcross = next.isAcross;
                           this.selectCell(next.cells[0]);
-                      } else {
-                          this.deselectCell(cell);
                       }
                   }
               }

--- a/client/components/CfzCrosswordGrid.vue
+++ b/client/components/CfzCrosswordGrid.vue
@@ -117,6 +117,7 @@ export default Vue.extend({
   props: {
     crossword: Object,
     moveToNextClueAtEnd: Boolean,
+    deselectAtEnd: Boolean,
     usingPencil: Boolean,
     showScratchpad: Boolean,
     answerSlots: {
@@ -353,6 +354,8 @@ export default Vue.extend({
                           const next = this.selectedClue.nextRef;
                           this.inputAcross = next.isAcross;
                           this.selectCell(next.cells[0]);
+                      } else if (this.deselectAtEnd) {
+                          this.deselectCell(cell);
                       }
                   }
               }


### PR DESCRIPTION
Looking at the guardian as an [example](https://www.theguardian.com/crosswords/quick/15949), when you reach the end of the word, you just stay put.  The same way it works for backspace.  I think this makes the crossword easier to use because I don't need to reselect the clue if I want to change a character I just wrote.  If we implement the TAB key, I think it would be essential to keep track of what word we just completed.