### PR TITLE
Add "smartTab" feature

### DIFF
--- a/client/components/CfzClue.vue
+++ b/client/components/CfzClue.vue
@@ -3,7 +3,7 @@
         :class="{highlighted: selected || highlighted}"
         :data-solver-mask="solverMask"
         ref="item">
-        <div class="clue-directions" @click="directionsClicked()">
+        <div class="clue-directions" @click="directionsClicked(false, 0)">
             <div class="clue-id" :data-ref-text="!!clue.refText">{{clue.numberText}}<span class="hidden-print">{{clue.directionText}}</span><span v-if="clue.refText">,</span></div>
             <div class="clue-text" v-html="'<b>' + clue.refText + '</b> ' + clue.sanitizedText + ' ' + clue.sanitizedLengthText" :data-ref-text="!!clue.refText"></div>
         </div>
@@ -223,9 +223,9 @@ export default Vue.extend({
         }
         return sep;
     },
-    directionsClicked: function(forced) {
+    directionsClicked: function(forced, at_index) {
         for (let i = 0; i < this.$refs.inputs.length; i++) {
-            if (this.$refs.inputs[i].dataset.cellIndex == 0) {
+            if (this.$refs.inputs[i].dataset.cellIndex == at_index) {
                 this.$refs.inputs[i].click();
             }
         }
@@ -320,10 +320,6 @@ export default Vue.extend({
             case KeyCode.KEY_ESCAPE:
             case KeyCode.KEY_RETURN:
                 input.blur();
-                event.preventDefault();
-                break;
-            case KeyCode.KEY_TAB:
-                this.$emit('move-to-clue', {clue: this.clue, prev: event.shiftKey});
                 event.preventDefault();
                 break;
         }

--- a/client/components/CfzClueList.vue
+++ b/client/components/CfzClueList.vue
@@ -112,10 +112,14 @@ export default Vue.extend({
     }
   },
   methods: {
-    selectClue(clue) {
+    selectClue(clue, at_index) {
+        if (!at_index) {
+            // if not provided
+            at_index = 0;
+        }
         for (var i = 0; i < this.clues.length; i++) {
             if (this.clues[i].id == clue.id) {
-                this.$refs.items[i].directionsClicked(true)
+                this.$refs.items[i].directionsClicked(true, at_index);
                 break;
             }
         }

--- a/client/components/CfzCrosswordClues.vue
+++ b/client/components/CfzCrosswordClues.vue
@@ -188,7 +188,7 @@ export default Vue.extend({
         const clue = event.clue;
         const next = event.prev ? clue.prevNumericalClue : clue.nextNumericalClue;
         const nextList = next.isAcross ? this.$refs.acrossList : this.$refs.downList;
-        nextList.selectClue(next);
+        nextList.selectClue(next, event.at_index);
     },
   },
   data() {

--- a/client/components/CfzCrosswordClues.vue
+++ b/client/components/CfzCrosswordClues.vue
@@ -185,10 +185,7 @@ export default Vue.extend({
         nextList.selectClue(next);
     },
     moveToClue(event) {
-        const clue = event.clue;
-        const next = event.prev ? clue.prevNumericalClue : clue.nextNumericalClue;
-        const nextList = next.isAcross ? this.$refs.acrossList : this.$refs.downList;
-        nextList.selectClue(next, event.at_index);
+        nextList.selectClue(event.clue, event.at_index);
     },
   },
   data() {

--- a/client/components/CfzCrosswordGrid.vue
+++ b/client/components/CfzCrosswordGrid.vue
@@ -236,7 +236,7 @@ export default Vue.extend({
       this.selectCell(clue.cells[first_blank]);
 
       // propagate this event to update clue list to match
-      this.$emit('move-to-clue', {clue: this.clue, prev: event.shiftKey, at_index: index});
+      this.$emit('move-to-clue', {clue: clue, at_index: index});
     },
     findAndSetNextClue() {
       // find the next clue

--- a/client/components/CfzCrosswordGrid.vue
+++ b/client/components/CfzCrosswordGrid.vue
@@ -208,21 +208,32 @@ export default Vue.extend({
     },
   },
   methods: {
-    getNextClue() {
-      for (let [i, clue_i] of cw.acrossClues.entries()) {
-        if (clue_i.selected) {
-          if (i == cw.acrossClue.length - 1) {
-            return cw.downClues[0];
-          }
-          return cw.acrossClues[i + 1];
+    clueHasBlanks(clue) {
+      for (let cell of clue.cells) {
+        if (cell.contents == '') {
+          return true;
         }
       }
-      for (let [i, clue_i] of cw.downClues.entries()) {
-        if (clue_i.selected) {
-          if (i == cw.downClue.length - 1) {
-            return cw.acrossClues[0];
-          }
-          return cw.downClues[i + 1];
+      return false;
+    },
+    getNextClue() {
+      let found_selected = false;
+      for (let clue of cw.acrossClues.concat(cw.downClues)) {
+        if (found_selected && clueHasBlanks(clue)) {
+          return clue;
+        }
+        if (clue.selected) {
+          found_selected = true;
+        }
+      }
+      // now wrap around until we hit selected again
+      for (let clue of cw.acrossClues.concat(cw.downClues)) {
+        if (clueHasBlanks(clue)) {
+          return clue;
+        }
+        if (clue.selected) {
+          // No blanks on the puzzle, so stay put
+          return clue;
         }
       }
     },


### PR DESCRIPTION
This makes it so that when you hit tab or shift-tab, it looks for the next word with at least one blank.  And it highlights the first blank in that word.  This is the behavior on NYT, but not on Guardian.  It's gated by a flag.

To avoid repeating too much logic, I put the event emit in the logic of CfzCrosswordGrid.vue, and send the clue/cell over.  I'm not sure if this will work.