### PR TITLE
Fix bug causing "|" to encode as apostrophe

### DIFF
--- a/@confuzzle/puz-common/puz-common.js
+++ b/@confuzzle/puz-common/puz-common.js
@@ -90,19 +90,19 @@ function splitNulls(buf, encoding) {
 function replaceWordChars(text) {
     var s = text;
     // smart single quotes and apostrophe
-    s = s.replace(/[\u2018|\u2019|\u201A]/g, "\'");
+    s = s.replace(/\u2018|\u2019|\u201A/g, "\'");
     // smart double quotes
-    s = s.replace(/[\u201C|\u201D|\u201E]/g, "\"");
+    s = s.replace(/\u201C|\u201D|\u201E/g, "\"");
     // ellipsis
     s = s.replace(/\u2026/g, "...");
     // dashes
-    s = s.replace(/[\u2013|\u2014]/g, "-");
+    s = s.replace(/\u2013|\u2014/g, "-");
     // circumflex
     s = s.replace(/\u02C6/g, "^");
     // open angle bracket
     s = s.replace(/\u2039/g, "");
     // spaces
-    s = s.replace(/[\u02DC|\u00A0]/g, " ");
+    s = s.replace(/\u02DC|\u00A0/g, " ");
     return s;
 }
 


### PR DESCRIPTION
These regexes use both square-bracketed character classes and the `|` operator at the same time, when they only actually need to use one or the other. Since `|` doesn't mean anything special inside a character class, this causes literal `|` characters in clues to be converted to apostrophes.